### PR TITLE
More precise ranges and fix issue of drawing mimic aggro circle

### DIFF
--- a/NecroLens/Model/ESPObject.cs
+++ b/NecroLens/Model/ESPObject.cs
@@ -115,11 +115,11 @@ public class ESPObject
     public float SightRadian { get; set; } = 1.571f;
 
     /**
-     * Most monsters have different aggro distances. 10.8y is roughly a safe value. Expect PotD Mimics ... 14 ._.
+     * Most monsters have different aggro distances. 10.8y is roughly a safe value. Expect PotD Mimics ... 14.6 ._.
      */
     public float AggroDistance()
     {
-        return Type == ESPType.Mimic && DataIds.PalaceOfTheDeadMapIds.Contains(clientState.TerritoryType) ? 14f : 10.8f;
+        return Type == ESPType.Mimic && DataIds.PalaceOfTheDeadMapIds.Contains(clientState.TerritoryType) ? 14.6f : 10.8f;
     }
 
     public ESPAggroType AggroType()

--- a/NecroLens/Service/ESPService.cs
+++ b/NecroLens/Service/ESPService.cs
@@ -116,7 +116,7 @@ public class ESPService : IDisposable
 
             if (espObject.Type == ESPObject.ESPType.AccursedHoard && conf.ShowHoards)
             {
-                var chestRadius = type == ESPObject.ESPType.AccursedHoard ? 2.2f : 1f; // Make Hoards bigger
+                var chestRadius = type == ESPObject.ESPType.AccursedHoard ? 2.0f : 1f; // Make Hoards bigger
 
                 if (distance <= 35 && conf.HighlightCoffers)
                     ESPUtils.DrawCircleFilled(drawList, espObject, chestRadius, espObject.RenderColor(), 1f);
@@ -136,7 +136,7 @@ public class ESPService : IDisposable
             }
 
             if (conf.ShowTraps && type == ESPObject.ESPType.Trap)
-                ESPUtils.DrawCircleFilled(drawList, espObject, 1.2f, espObject.RenderColor());
+                ESPUtils.DrawCircleFilled(drawList, espObject, 1.7f, espObject.RenderColor());
 
             if (conf.ShowMimicCoffer && type == ESPObject.ESPType.MimicChest)
                 ESPUtils.DrawCircleFilled(drawList, espObject, 1f, espObject.RenderColor());
@@ -145,7 +145,7 @@ public class ESPService : IDisposable
                 ESPUtils.DrawCircleFilled(drawList, espObject, 2f, espObject.RenderColor());
         }
 
-        if (PluginService.Configuration.ShowMobViews && type is ESPObject.ESPType.Enemy &&
+        if (PluginService.Configuration.ShowMobViews && (type == ESPObject.ESPType.Enemy || type == ESPObject.ESPType.Mimic) &&
             BattleNpcSubKind.Enemy.Equals((BattleNpcSubKind)espObject.GameObject.SubKind) &&
             !espObject.InCombat())
         {

--- a/NecroLens/util/DataIds.cs
+++ b/NecroLens/util/DataIds.cs
@@ -53,7 +53,7 @@ public static class DataIds
 
     public static readonly HashSet<uint> MimicIDs = new()
     {
-        2566, 6362, 6363, 7392, 7393, 7394, 5832, 15997, 15998, 15999, 16002, 16003
+        2566, 6362, 6363, 7392, 7393, 7394, 5832, 5834, 5835, 15997, 15998, 15999, 16002, 16003
     };
 
     public static readonly HashSet<uint> BronzeChestIDs = new()


### PR DESCRIPTION
1. More precise PotD mimic aggro range; trap and accursed hoard trigger range.
2. Add some dataids of mimics.
3. Fix the bug that if MimicIDs.Contains(PotD mimic's dataID) == false, service draws a circle of radius 10.8y, else doesn't draw circle at all)