### PR TITLE
Use GameObject hitbox to calculate aggro distance

### DIFF
--- a/NecroLens/Model/ESPObject.cs
+++ b/NecroLens/Model/ESPObject.cs
@@ -119,7 +119,7 @@ public class ESPObject
      */
     public float AggroDistance()
     {
-        return Type == ESPType.Mimic && DeepDungeonUtil.InPotD ? 14.6f : 10.8f;
+        return GameObject.HitboxRadius + (Type == ESPType.Mimic && DeepDungeonUtil.InPotD ? 14f : 10f);
     }
 
     public ESPAggroType AggroType()


### PR DESCRIPTION
Use GameObject hitbox to calculate aggro distance. This produces an accurate aggro distance for stationary enemies.