### PR TITLE
api14 and 7.4 changes

### DIFF
--- a/NecroLens/Model/ESPObject.cs
+++ b/NecroLens/Model/ESPObject.cs
@@ -49,11 +49,13 @@ public class ESPObject
     }
 
     private IClientState clientState;
+    private IObjectTable objectTable;
     private MobInfo? mobInfo;
 
     public ESPObject(IGameObject gameObject, MobInfo? mobInfo = null)
     {
         this.clientState = ClientState;
+        this.objectTable = ObjectTable;
         ContainingPomander = null;
         GameObject = gameObject;
         this.mobInfo = mobInfo;
@@ -79,7 +81,7 @@ public class ESPObject
         {
             var dataId = gameObject.BaseId;
 
-            if (clientState.LocalPlayer != null && clientState.LocalPlayer.EntityId == gameObject.EntityId)
+            if (objectTable.LocalPlayer != null && objectTable.LocalPlayer.EntityId == gameObject.EntityId)
                 Type = ESPType.Player;
             else if (DataIds.BronzeChestIDs.Contains(dataId))
                 Type = ESPType.BronzeChest;
@@ -172,7 +174,7 @@ public class ESPObject
 
     public float Distance()
     {
-        return clientState.LocalPlayer != null ? GameObject.Position.Distance2D(clientState.LocalPlayer.Position) : 0;
+        return objectTable.LocalPlayer != null ? GameObject.Position.Distance2D(objectTable.LocalPlayer.Position) : 0;
     }
 
     public bool IsChest()

--- a/NecroLens/NecroLens.csproj
+++ b/NecroLens/NecroLens.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Dalamud.NET.Sdk/13.0.0">
+<Project Sdk="Dalamud.NET.Sdk/14.0.1">
     <PropertyGroup>
         <Authors>Jukka</Authors>
         <Version>0.0.0.0</Version>
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
+        <TargetFramework>net10.0-windows7.0</TargetFramework>
         <Platforms>x64</Platforms>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -43,7 +43,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="ECommons" Version="3.0.1.3" />
+        <PackageReference Include="ECommons" Version="3.1.0.6" />
         <Reference Include="FFXIVClientStructs">
             <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
             <Private>false</Private>

--- a/NecroLens/NecroLens.json
+++ b/NecroLens/NecroLens.json
@@ -5,7 +5,6 @@
     "Description": "DeepDungeon Helper. Radar for Mobs, Aggro, Sight and everything else.",
     "InternalName": "NecroLens",
     "ApplicableVersion": "any",
-    "DalamudApiLevel": 13,
     "Tags": [
         "potd",
         "hoh",

--- a/NecroLens/Service/DeepDungeonService.cs
+++ b/NecroLens/Service/DeepDungeonService.cs
@@ -33,7 +33,7 @@ public class DeepDungeonService : IDisposable
     public readonly Dictionary<Pomander, string> PomanderNames;
     
     private const string ActorControlSig = "E8 ?? ?? ?? ?? 0F B7 0B 83 E9 64";
-    private delegate void ActorControlSelfDelegate(uint category, uint eventId, uint param1, uint param2, uint param3, uint param4, uint param5, uint param6, ulong targetId, byte param7);
+    private delegate void ActorControlSelfDelegate(uint category, uint eventId, uint param1, uint param2, uint param3, uint param4, uint param5, uint param6, uint param7, uint param8, ulong targetId, byte param9);
     private Hook<ActorControlSelfDelegate>? actorControlSelfHook;
     
     
@@ -138,9 +138,9 @@ public class DeepDungeonService : IDisposable
         FloorTimes[FloorDetails.CurrentFloor] = time;
     }
 
-    private void ActorControlSelf(uint category, uint eventId, uint param1, uint param2, uint param3, uint param4, uint param5, uint param6, ulong targetId, byte param7)
+    private void ActorControlSelf(uint category, uint eventId, uint param1, uint param2, uint param3, uint param4, uint param5, uint param6, uint param7, uint param8, ulong targetId, byte param9)
     {
-        actorControlSelfHook!.Original(category, eventId, param1, param2, param3, param4, param5, param6, targetId, param7);
+        actorControlSelfHook!.Original(category, eventId, param1, param2, param3, param4, param5, param6, param7, param8, targetId, param9);
 
         if (eventId == 100 && !Ready && DeepDungeonContentInfo.ContentInfo.TryGetValue((int)param2, out var info))
             EnterDeepDungeon((int)param2, info);
@@ -186,7 +186,7 @@ public class DeepDungeonService : IDisposable
                     var pomander = (Pomander)args[0];
                     if (pomander > 0)
                     {
-                        var player = ClientState.LocalPlayer!;
+                        var player = ObjectTable.LocalPlayer!;
                         var chest = ObjectTable
                                     .Where(o => o.BaseId == DataIds.GoldChest)
                                     .FirstOrDefault(o => o.Position.Distance2D(player.Position) <= 4.6f);
@@ -218,7 +218,7 @@ public class DeepDungeonService : IDisposable
 
     internal unsafe void TryInteract(ESPObject espObj)
     {
-        var player = ClientState.LocalPlayer!;
+        var player = ObjectTable.LocalPlayer!;
         if ((player.StatusFlags & StatusFlags.InCombat) == 0 && conf.OpenChests && espObj.IsChest())
         {
             var type = espObj.Type;

--- a/NecroLens/Service/ESPService.cs
+++ b/NecroLens/Service/ESPService.cs
@@ -192,7 +192,8 @@ public class ESPService : IDisposable
                !(Condition[ConditionFlag.LoggingOut] ||
                  Condition[ConditionFlag.BetweenAreas] ||
                  Condition[ConditionFlag.BetweenAreas51]) &&
-               ClientState is { LocalPlayer: not null, LocalContentId: > 0 }
+                 ObjectTable.LocalPlayer != null &&
+                 PlayerState.ContentId > 0
                 && DeepDungeonUtil.InDeepDungeon;
     }
 
@@ -229,8 +230,8 @@ public class ESPService : IDisposable
                         DungeonService.TrackFloorObjects(espObj);
                     }
 
-                    if (ClientState.LocalPlayer != null &&
-                        ClientState.LocalPlayer.EntityId == obj.EntityId)
+                    if (ObjectTable.LocalPlayer != null &&
+                        PlayerState.EntityId == obj.EntityId)
                         entityList.Add(new ESPObject(obj));
                 }
 

--- a/NecroLens/Service/ESPTestService.cs
+++ b/NecroLens/Service/ESPTestService.cs
@@ -29,7 +29,7 @@ public class ESPTestService : IDisposable
         if (ShouldDraw())
         {
             var drawList = ImGui.GetBackgroundDrawList();
-            var player = ClientState.LocalPlayer;
+            var player = ObjectTable.LocalPlayer;
             var espObject = new ESPObject(player!);
 
             var onScreen = GameGui.WorldToScreen(player!.Position, out _);
@@ -51,7 +51,7 @@ public class ESPTestService : IDisposable
         return !(Condition[ConditionFlag.LoggingOut] ||
                  Condition[ConditionFlag.BetweenAreas] ||
                  Condition[ConditionFlag.BetweenAreas51]) &&
-               ClientState.LocalPlayer != null &&
-               ClientState.LocalContentId > 0 && ObjectTable.Length > 0;
+               ObjectTable.LocalPlayer != null &&
+               PlayerState.ContentId > 0 && ObjectTable.Length > 0;
     }
 }

--- a/NecroLens/Service/PluginService.cs
+++ b/NecroLens/Service/PluginService.cs
@@ -21,6 +21,9 @@ public class PluginService
     public static IClientState ClientState { get; private set; } = null!;
 
     [PluginService]
+    public static IPlayerState PlayerState { get; private set; } = null!;
+
+    [PluginService]
     public static ICommandManager CommandManager { get; private set; } = null!;
 
     [PluginService]

--- a/NecroLens/packages.lock.json
+++ b/NecroLens/packages.lock.json
@@ -1,24 +1,24 @@
 {
   "version": 1,
   "dependencies": {
-    "net9.0-windows7.0": {
+    "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[13.0.0, )",
-        "resolved": "13.0.0",
-        "contentHash": "Mb3cUDSK/vDPQ8gQIeuCw03EMYrej1B4J44a1AvIJ9C759p9XeqdU9Hg4WgOmlnlPe0G7ILTD32PKSUpkQNa8w=="
+        "requested": "[14.0.1, )",
+        "resolved": "14.0.1",
+        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",
-        "requested": "[1.2.25, )",
-        "resolved": "1.2.25",
-        "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
+        "requested": "[1.2.39, )",
+        "resolved": "1.2.39",
+        "contentHash": "fcFN01tDTIQqDuTwr1jUQK/geofiwjG5DycJQOnC72i1SsLAk1ELe+apBOuZ11UMQG8YKFZG1FgvjZPbqHyatg=="
       },
       "ECommons": {
         "type": "Direct",
-        "requested": "[3.0.1.3, )",
-        "resolved": "3.0.1.3",
-        "contentHash": "EmI3VUDSR8BOPFTCiEm0s/N3iSHg3u9iolyOys/lsJF0b3OtI3NvqxLLbrSlACOrtSSohOVVf7FnXupKKNLN/Q=="
+        "requested": "[3.1.0.6, )",
+        "resolved": "3.1.0.6",
+        "contentHash": "R17fNKyTD5ECL8EustEdjVZc5kbN5WQ4rK/SbSCVzQT6jQtzNC5xjrSBRz3W+YXVHCtyNJ1Aymqh80R4nfDuZA=="
       }
     }
   }

--- a/NecroLensDataTools/NecroLensDataTools.csproj
+++ b/NecroLensDataTools/NecroLensDataTools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0-windows7.0</TargetFramework>
+        <TargetFramework>net10.0-windows7.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>


### PR DESCRIPTION
switched ``IClientState.LocalPlayer`` to ``IObjectTable.LocalPlayer`` and ``IClientState.LocalContentId`` to ``IPlayerState.ContentId`` as former ones are now obsolete
updated params count in ActorControl to resolve mismatch (old sig looks ok as floors still do update on traversal)
bumped targetFramework to net10
bumped Dalamud.SDK version, removed apiLevel as it's deduced automatically and no longer needed
bumped ECommons to 3.1.0.6

NP: package.lock.json looks excessive in repo as it regens via SDK, tho included it to keep repo consistent